### PR TITLE
[GST-1327] Adds aws cluster discovery to Zookeeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 
 all: test clean
 
+watch: test_deps
+	while sleep 1; do \
+		find defaults/ handlers/ meta/ tasks/ templates/ tests/vagrant/test.yml \
+		| entr -d make vagrant_up; \
+	done
+
 test: test_deps vagrant_up
 
 integration_test: clean integration_test_deps vagrant_up clean
@@ -10,6 +16,7 @@ integration_test: clean integration_test_deps vagrant_up clean
 test_deps:
 	rm -rf tests/vagrant/sansible.*
 	ln -s ../.. tests/vagrant/sansible.zookeeper
+	ansible-galaxy install --force -p tests/vagrant -r tests/vagrant/local_requirements.yml
 
 integration_test_deps:
 	sed -i.bak \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Develop: ![Build Status](https://travis-ci.org/sansible/zookeeper.svg?branch=dev
 * [ansible.cfg](#ansible-cfg)
 * [Dependencies](#dependencies)
 * [Tags](#tags)
+* [AWS Cluster Autodiscovery](#aws-cluster-autodiscovery)
 * [Examples](#examples)
 
 This roles installs Apache Zookeeper server.
@@ -52,6 +53,19 @@ This role uses two tags: **build** and **configure**
 
 * `build` - Installs Zookeeper server and all it's dependencies.
 * `configure` - Configure and ensures that the Zookeeper service is running.
+
+
+
+
+## AWS Cluster Autodiscovery
+
+The [AWS Autodiscover script](/files/aws_cluster_autodiscover) allows machines to pick an 
+ID and a hostname from a predefined list, AWS tags are used to mark machines that have 
+claimed an ID/host.
+
+This script allows for a static set of hostnames with consistent IDs, the details of the machines that 
+claim these details can change, so no need for hardcoded IPs or network drives. As long as a machine is 
+recognised by the rest of the cluster then it will automatically join and sync with the other machines.
 
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,23 +1,29 @@
 ---
 
 zookeeper:
-  # Variables only for RedHat family
-  #url: https://archive.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
   client_port: 2181
-  data_dir: /var/lib/zookeeper
-  dir: /opt/zookeeper-*version
-  hosts: "{{ ansible_fqdn }}:2181"
-  hosts: [ ]
-  log_dir: /var/log/zookeeper
+  connect_port: 2888
+  conf_dir: /home/zookeeper/etc
+  data_dir: /home/zookeeper/lib
+  election_port: 3888
+  group: zookeeper
+  hosts:
+    - localhost
+  id: 1
+  install_dir: /home/zookeeper/zookeeper
+  java_opts: "-Xmx{{ (ansible_memtotal_mb / 2) | int }}m -Xms{{ (ansible_memtotal_mb / 2) | int }}m"
+  # note this is for application logs, not the actual zookeeper data logs
+  log_dir: /home/zookeeper/log
   log_level: WARN
-  maxClientCnxns: 60
-  monasca_download_dir: "/opt/monasca/"
-  run_mode: Deploy
-  version: &version 3.4.6
-  wait_for_period: 30
+  user: zookeeper
+  version: 3.4.8
 
-  os_conf_dir:
-    Debian: "/etc/zookeeper/conf"
-
-  # Common
-  conf_dir: /etc/zookeeper/conf
+  # If enabled AWS will be used to figure out which host and id should be used
+  # Note that you must install the AWS CLI tools on the machine to use this feature
+  aws_cluster_autodiscover:
+    enabled: false
+    # Tag to store the ID/index of the host that gets assigned to a machine
+    id_tag_name: ZookeeperID
+    # AWS CLI lookup filter
+    lookup_filter: "Name=tag:Environment,Values=dev Name=tag:Role,Values=zookeeper"
+    r53_zone_id: ~

--- a/files/aws_cluster_autodiscover
+++ b/files/aws_cluster_autodiscover
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -o nounset
+
+# Gaffa tape script that uses AWS tags to pick an available ID/Index from a list of hostnames
+# This ID can be used to assign then pick the hostname and machine ID for services that require such a setting
+# such as Kafka or Zookeeper.
+#
+# NOTE In the future we should replace this with Consul.
+#
+# Usage:
+# aws_cluster_autodiscover [Max number of machines in cluster] [AWS hostedzone ID] "[AWS ec2 describe-instances filter]" [Name of tag used to store id]
+# eg.
+# ./bin/aws_cluster_autodiscover "01.zookeeper.app.internal,02.zookeeper.app.internal,03.zookeeper.app.internal" "Z8LHX0FIHPY9F" "Name=tag:Environment,Values=dev Name=tag:Role,Values=zookeeper" "ZookeeperID"
+#
+# Returns:
+# Json array detaling the claimed ID and hostname
+# eg.
+# {"id": "1", "id_index0": "0", "hostname": "01.zookeeper.app.internal", "info": "Machine had no ID, claimed ID and R53 entry" }
+
+function die {
+	echo -e "\033[1;31mError: $1\033[0m"
+	exit 1
+}
+
+function output {
+	local -i CLAIMED_ID=$1
+	local CLAIMED_HOST=$2
+	local INFO=$3
+	local -i CLAIMED_ID_INDEX0=$((CLAIMED_ID - 1 ))
+	echo "{\"id\": \"${CLAIMED_ID}\", \"id_index0\": \"${CLAIMED_ID_INDEX0}\", \"hostname\": \"${CLAIMED_HOST}\", \"info\": \"${INFO}\" }"
+	exit 0
+}
+
+function main {
+	# Arguments
+	if [ "$#" -ne 4 ]; then
+		die "This script takes 4 parameters, only $# given"
+	fi
+	local HOSTS=(${1//,/ })
+	local HOSTED_ZONE_ID=$2
+	local LOOKUP_FILTER=$3
+	local ID_TAG_NAME=$4
+
+	# Initialise vars before usage since local always returns 0
+	local MAX_HOSTS=${#HOSTS[@]}
+	local CLAIMED_ID=""
+	local CLAIMED_HOST=""
+	local INSTANCE_ID=""
+	local INSTANCE_IP=""
+	local INSTANCE_REGION=""
+	local AVAILABLE_IDS=( )
+	local CLAIMED_IDS=( )
+	local UNCLAIMED_IDS=( )
+
+	INSTANCE_ID=$( curl -f -s http://169.254.169.254/latest/meta-data/instance-id/ )
+	INSTANCE_IP=$( curl -f -s http://169.254.169.254/latest/meta-data/local-ipv4/ )
+	INSTANCE_REGION=$( curl -f -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed -e '$s/.$//' )
+	if [[ -z ${INSTANCE_ID} || -z ${INSTANCE_IP} || -z ${INSTANCE_REGION} ]]; then
+		die "Could not grab instance ID or IP, are you running outside of EC2?"
+	fi
+
+	# Check to see if this machine has an ID tag already
+	CLAIMED_ID=$( aws ec2 describe-tags \
+		--region ${INSTANCE_REGION} \
+		--filter "Name=resource-id,Values=${INSTANCE_ID}" \
+		--output text "Name=key,Values=${ID_TAG_NAME}" \
+		--query "Tags[*].Value" )
+	if [[ -n ${CLAIMED_ID} ]]; then
+		output "${CLAIMED_ID}" "${HOSTS[$CLAIMED_ID - 1]}" "Machine already has an ID"
+	fi
+
+	# Figure out which ID and host to claim
+	AVAILABLE_IDS=( $(seq 1 "${MAX_HOSTS}") )
+	CLAIMED_IDS=( $( aws ec2 describe-instances \
+		--region ${INSTANCE_REGION} \
+		--filters ${LOOKUP_FILTER} Name=instance-state-name,Values=running \
+		--output text \
+		--query "Reservations[*].Instances[*].Tags[*] | [] | [] | [?Key=='${ID_TAG_NAME}'] | [*].Value" ) )
+	if [[ "${#CLAIMED_IDS[@]}" -gt 0 ]]; then
+		# Use comm to diff the ID arrays
+		UNCLAIMED_IDS=( $( comm -13 \
+			<(for X in "${CLAIMED_IDS[@]}"; do echo "${X}"; done | sort) \
+			<(for X in "${AVAILABLE_IDS[@]}"; do echo "${X}"; done | sort) ) )
+
+		if [ ${#UNCLAIMED_IDS[@]} -eq 0 ]; then
+			# No free IDs, throw an error
+			die "No free IDs found, aborting"
+		fi
+
+		# Claim the first free ID
+		CLAIMED_ID="${UNCLAIMED_IDS[0]}"
+	else
+		# No IDs have been claimed, grab the first one
+		CLAIMED_ID="1"
+	fi
+
+	CLAIMED_HOST="${HOSTS[$CLAIMED_ID - 1]}"
+
+	# Claim the hostname
+	aws route53 change-resource-record-sets \
+		--region ${INSTANCE_REGION} \
+		--hosted-zone-id ${HOSTED_ZONE_ID} \
+		--change-batch "{ \"Changes\": [ { \"Action\": \"UPSERT\", \"ResourceRecordSet\": { \"Name\": \"${CLAIMED_HOST}\", \"Type\": \"A\", \"TTL\": 300, \"ResourceRecords\": [ { \"Value\": \"${INSTANCE_IP}\" } ] } } ] }" \
+		> /dev/null 2>&1 \
+		|| die "Failed to update R53 entry for ${CLAIMED_HOST}"
+
+	# Claim the ID
+	aws ec2 create-tags \
+		--region ${INSTANCE_REGION} \
+		--resources ${INSTANCE_ID} \
+		--tags Key=${ID_TAG_NAME},Value=${CLAIMED_ID} \
+		> /dev/null 2>&1 \
+		|| die "Failed to update Tag entry for with ID ${CLAIMED_ID}"
+
+	output "${CLAIMED_ID}" "${CLAIMED_HOST}" "Machine had no ID, claimed ID and R53 entry"
+}
+
+main "$@"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 
 galaxy_info:
   author: "Wojtek Oledzki"
-  description: "Install Apache Zookeeper server."
+  description: "Install Apache Zookeeper."
   license: MIT
   min_ansible_version: 1.9
   platforms:
@@ -12,4 +12,14 @@ galaxy_info:
   categories:
     - development
 
-dependencies: [ ]
+dependencies:
+  - role: sansible.users_and_groups
+    version: v1.0
+    users_and_groups:
+      groups:
+        - name: zookeeper
+      users:
+        - name: zookeeper
+          group: zookeeper
+    tags:
+      - build

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,9 +1,58 @@
 ---
 
-- name: Install Zookeeper
-  sudo: yes
+- name: Install Zookeeper supporting packages
+  become: yes
   apt:
     name: "{{ item }}"
   with_items:
     - openjdk-7-jre-headless
-    - zookeeperd
+
+- name: Create Zookeeper directories
+  become: yes
+  become_user: "{{ zookeeper.user }}"
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "/home/{{ zookeeper.user }}/bin"
+    - "{{ zookeeper.conf_dir }}"
+    - "{{ zookeeper.data_dir }}"
+    - "{{ zookeeper.log_dir }}"
+
+- name: Download ZooKeeper
+  become: yes
+  become_user: "{{ zookeeper.user }}"
+  get_url:
+    url: "http://www.mirrorservice.org/sites/ftp.apache.org/zookeeper/zookeeper-{{ zookeeper.version }}/zookeeper-{{ zookeeper.version }}.tar.gz"
+    dest: "/home/{{ zookeeper.user }}/zookeeper-{{ zookeeper.version }}.tar.gz"
+
+- name: Unpack Zookeeper
+  become: yes
+  become_user: "{{ zookeeper.user }}"
+  unarchive:
+    copy: no
+    creates: "/home/{{ zookeeper.user }}/zookeeper-{{ zookeeper.version }}"
+    dest: "/home/{{ zookeeper.user }}"
+    src: "/home/{{ zookeeper.user }}/zookeeper-{{ zookeeper.version }}.tar.gz"
+
+- name: Link to Zookeeper Directory
+  become: yes
+  become_user: "{{ zookeeper.user }}"
+  file:
+    dest: "{{ zookeeper.install_dir }}"
+    src: "/home/{{ zookeeper.user }}/zookeeper-{{ zookeeper.version }}"
+    state: link
+
+- name: Create Zookeeper service
+  become: yes
+  template:
+    dest: /etc/init/zookeeper.conf
+    mode: 644
+    owner: root
+    src: zookeeper.service.j2
+
+- name: Ensure Zookeeper runs on boot
+  become: yes
+  service:
+    enabled: yes
+    name: zookeeper

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,58 +1,82 @@
 ---
 
-- name: Setup zoo.cfg file
+- name: Copy AWS autodiscover script
   become: yes
-  template:
-    dest: "{{ zookeeper.conf_dir }}/zoo.cfg"
-    src: zoo.cfg.j2
-  notify:
-    - restart zookeeper
+  become_user: "{{ zookeeper.user }}"
+  copy:
+    src: aws_cluster_autodiscover
+    dest: "/home/{{ zookeeper.user }}/bin/aws_cluster_autodiscover"
+    owner: "{{ zookeeper.user }}"
+    group: "{{ zookeeper.group }}"
+    mode: 0750
+  when: zookeeper.aws_cluster_autodiscover.enabled
+
+- name: Run AWS autodiscover script and grab ID
+  become: yes
+  become_user: "{{ zookeeper.user }}"
+  command: "./aws_cluster_autodiscover {{ zookeeper.hosts | join(',') }} {{ zookeeper.aws_cluster_autodiscover.r53_zone_id }} \"{{ zookeeper.aws_cluster_autodiscover.lookup_filter }}\" {{ zookeeper.aws_cluster_autodiscover.id_tag_name}}"
+  args:
+    chdir: "/home/{{ zookeeper.user }}/bin"
+  register: aws_cluster_autodiscover
+  when: zookeeper.aws_cluster_autodiscover.enabled
+
+- name: Set autodiscover id based AWS autodiscover script
+  set_fact:
+    zookeeper:
+      aws_cluster_autodiscover:
+        data: "{{ aws_cluster_autodiscover.stdout | from_json }}"
+  when: zookeeper.aws_cluster_autodiscover.enabled
 
 - name: Setup myid
   become: yes
+  become_user: "{{ zookeeper.user }}"
   template:
-    dest: "{{ zookeeper.conf_dir }}/myid"
+    dest: "{{ zookeeper.data_dir }}/myid"
     src: myid.j2
   notify:
-    - restart zookeeper
+   - restart zookeeper
 
-- name: Setup environment
+- name: Setup zoo.cfg file
   become: yes
+  become_user: "{{ zookeeper.user }}"
   template:
-    dest: "{{ zookeeper.conf_dir }}/environment"
-    src: environment.j2
+    dest: "{{ zookeeper.conf_dir }}/zoo.cfg"
+    mode: 0644
+    src: zoo.cfg.j2
   notify:
-    - restart zookeeper
+   - restart zookeeper
 
-- name: Create log_dir
+- name: Create Zookeeper log4j config
   become: yes
-  file:
-    path: "{{ zookeeper.log_dir }}"
-    state: directory
-    owner: zookeeper
-    group: zookeeper
-    mode: 755
-
-- name: Setup log4j
-  become: yes
+  become_user: "{{ zookeeper.user }}"
   template:
     dest: "{{ zookeeper.conf_dir }}/log4j.properties"
-    owner: root
-    group: root
-    mode: 644
+    mode: 0644
     src: log4j.properties.j2
   notify:
     - restart zookeeper
 
-- name: Ensure Zookeeper is running
+- name: Setup Zookeeper environment config
+  become: yes
+  become_user: "{{ zookeeper.user }}"
+  template:
+    dest: "{{ zookeeper.conf_dir }}/environment"
+    mode: 0644
+    src: environment.j2
+  notify:
+    - restart zookeeper
+
+- name: Start Zookeeper service
   become: yes
   service:
     name: zookeeper
     state: started
-    enabled: yes
 
-- name: wait for zookeeper port
+- name: Flush handlers to ensure Zookeeper is up to date
+  meta: flush_handlers
+
+- name: Wait for Zookeeper port
   wait_for:
     port: "{{ zookeeper.client_port }}"
     state: started
-    timeout: "{{ zookeeper.wait_for_period }}"
+    timeout: 30

--- a/templates/environment.j2
+++ b/templates/environment.j2
@@ -2,9 +2,9 @@
 # Modified from http://packages.ubuntu.com/saucy/zookeeperd
 NAME=zookeeper
 ZOOCFGDIR={{ zookeeper.conf_dir }}
+ZOODIR={{ zookeeper.install_dir }}
 
-# seems, that log4j requires the log4j.properties file to be in the classpath
-CLASSPATH="$ZOOCFGDIR:/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar"
+CLASSPATH="$ZOOCFGDIR:$ZOODIR/zookeeper-{{ zookeeper.version }}.jar:{{ zookeeper.classpath | default('$ZOODIR/lib/*') }}"
 
 ZOOCFG="$ZOOCFGDIR/zoo.cfg"
 ZOO_LOG_DIR={{ zookeeper.log_dir }}
@@ -17,8 +17,4 @@ JAVA=/usr/bin/java
 ZOOMAIN="org.apache.zookeeper.server.quorum.QuorumPeerMain"
 ZOO_LOG4J_PROP="INFO,ROLLINGFILE"
 JMXLOCALONLY=false
-{% if zookeeper_heap_opt is defined %}
-JAVA_OPTS="{{ zookeeper.heap_opt  }}"
-{% else %}
-JAVA_OPTS=""
-{% endif %}
+JAVA_OPTS="{{ zookeeper.java_opts | default() }}"

--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -1,10 +1,5 @@
-{%- if zookeeper.id is defined -%}
-{{ zookeeper.id  }}
+{%- if zookeeper.aws_cluster_autodiscover.data is defined -%}
+{{ zookeeper.aws_cluster_autodiscover.data.id }}
 {%- else -%}
-  {%- for url in zookeeper.hosts -%}
-    {%- set url_host = url.split(':')[0] -%}
-    {%- if url_host == ansible_fqdn or url_host in ansible_all_ipv4_addresses -%}
-{{ loop.index0  }}
-    {%- endif -%}
-  {%- endfor -%}
+{{ zookeeper.id }}
 {%- endif -%}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -7,9 +7,9 @@ tickTime=2000
 initLimit=10
 # The number of ticks that can pass between
 # sending a request and getting an acknowledgement
-syncLimit=5
+syncLimit=25
 # the directory where the snapshot is stored.
-dataDir=/var/lib/zookeeper
+dataDir={{ zookeeper.data_dir }}
 # Place the dataLogDir to a separate physical disc for better performance
 # dataLogDir=/disk2/zookeeper
 
@@ -17,7 +17,6 @@ dataDir=/var/lib/zookeeper
 clientPort={{ zookeeper.client_port }}
 
 # Maximum number of clients that can connect from one client
-maxClientCnxns={{ zookeeper.maxClientCnxns }}
 
 {#
 # specify all zookeeper servers
@@ -25,7 +24,7 @@ maxClientCnxns={{ zookeeper.maxClientCnxns }}
 # The second one is used for leader election
 #}
 {% for url in zookeeper.hosts %}
-server.{{ loop.index0}}={{url.split(':')[0] }}:2888:3888
+server.{{ loop.index}}={{url.split(':')[0] }}:2888:3888
 {% endfor %}
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in

--- a/templates/zookeeper.service.j2
+++ b/templates/zookeeper.service.j2
@@ -1,23 +1,28 @@
-[Unit]
-Description=Apache ZooKeeper
-After=network.target
-ConditionPathExists={{ zookeeper.conf_dir  }}/zoo.cfg
-ConditionPathExists={{ zookeeper.conf_dir  }}/log4j.properties
+description "zookeeper centralized coordination service"
 
-[Service]
-Type=forking
-User=root
-SyslogIdentifier=zookeeper
-WorkingDirectory={{ zookeeper.data_dir  }}
-UMask=0027
-Environment="ZOOCFGDIR={{ zookeeper.conf_dir  }}"
-Environment="ZOO_LOG_DIR={{ zookeeper.log_dir }}"
-Environment="JMXLOCALONLY=false"
-Environment="ZOO_LOG4J_PROP=INFO,ROLLINGFILE"
-ExecStart={{ zookeeper.dir  }}/bin/zkServer.sh start
-ExecStop={{ zookeeper.dir  }}/bin/zkServer.sh stop
-ExecReload={{ zookeeper.dir  }}/bin/zkServer.sh restart
-Restart=on-failure
+start on runlevel [2345]
+stop on runlevel [!2345]
 
-[Install]
-WantedBy=multi-user.target
+respawn
+
+limit nofile 8192 8192
+
+pre-start script
+	[ -r "{{ zookeeper.install_dir }}/zookeeper-{{ zookeeper.version }}.jar" ] || exit 0
+	[ -r "{{ zookeeper.conf_dir }}/environment" ] || exit 0
+	. {{ zookeeper.conf_dir }}/environment
+	[ -d $ZOO_LOG_DIR ] || mkdir -p $ZOO_LOG_DIR
+	chown $USER:$GROUP $ZOO_LOG_DIR
+end script
+
+script
+	. {{ zookeeper.conf_dir }}/environment
+	[ -r /etc/default/zookeeper ] && . /etc/default/zookeeper
+	if [ -z "$JMXDISABLE" ]; then
+		JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=$JMXLOCALONLY"
+	fi
+	exec start-stop-daemon --start -c $USER --exec $JAVA --name zookeeper \
+		-- -cp $CLASSPATH $JAVA_OPTS -Dzookeeper.log.dir=${ZOO_LOG_DIR} \
+		 -Dzookeeper.root.logger=${ZOO_LOG4J_PROP} \
+		 $ZOOMAIN $ZOOCFG
+end script

--- a/tests/vagrant/integration_requirements.yml
+++ b/tests/vagrant/integration_requirements.yml
@@ -1,5 +1,4 @@
 ---
 
-- name: sansible.php
-  src: git+git@github.com:sansible/php.git
-  version: origin/master
+- src: sansible.users_and_groups
+  version: v1.0

--- a/tests/vagrant/local_requirements.yml
+++ b/tests/vagrant/local_requirements.yml
@@ -1,5 +1,4 @@
 ---
 
-- name: sansible.users_and_groups
-  src: https://github.com/sansible/users_and_groups.git
-  scm: git
+- src: sansible.users_and_groups
+  version: v1.0


### PR DESCRIPTION
This allows zookeeper machines to discover which id and hostname they should use in AWS, this will allow machines to be replaced if they die without disruption/manual intervention. Rolling AMI updates are also possible.

Also updates the role so can use new releases of Zookeeper as opposed to the version available via apt.