### PR TITLE
Update zookeeper version to 3.4.14

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,5 +29,5 @@ sansible_zookeeper_max_open_files: 4098
 sansible_zookeeper_sync_limit: 25
 sansible_zookeeper_tick_time: 2000
 sansible_zookeeper_user: zookeeper
-sansible_zookeeper_version: 3.4.13
+sansible_zookeeper_version: 3.4.14
 sansible_zookeeper_wait_for_server: 60


### PR DESCRIPTION
According to http://apache.mirror.anlx.net/zookeeper/ there is no more 3.4.13 version available.
The next closest version is 3.4.14.